### PR TITLE
Require explicitely python2

### DIFF
--- a/mimic
+++ b/mimic
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # coding=utf-8
 
 


### PR DESCRIPTION
Some distros have /usr/bin/python linked to python3 (eg. Archlinux);
explicitely require /usr/bin/python2.