### PR TITLE
Fix shebang, the fact that it crashes under py3k

### DIFF
--- a/mimic
+++ b/mimic
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding=utf-8
 
 
@@ -6,7 +6,7 @@ import sys
 
 
 if not ((2, 7) <= sys.version_info < (3,)):
-    print 'Python 2.x required.'
+    print('Python 2.x required.')
     exit(1)
 
 

--- a/mimic
+++ b/mimic
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # coding=utf-8
 
 


### PR DESCRIPTION
Exactly as the title sounds. This script would utterly break under Arch Linux where /usr/bin/python is python 3. Also, in the python 3 detection, the print statement causes a crash.