### PR TITLE
add minimal support for installation via pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .idea
+__pycache__
+*.pyc
+*.egg-info
+

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ Or, if you've been mimicked a little harder,
 <img alt="some worse code"
      src="https://cloud.githubusercontent.com/assets/1236420/10564914/f7963ae4-7591-11e5-9b45-f123e42b22f4.png" />
 
+### Installation
+
+Install mimic directly via pip:
+
+```
+pip install git+git://github.com/reinderien/mimic.git
+```
+
 ### See also
 
 [Wikipedia: Unicode Equivalence] (https://en.wikipedia.org/wiki/Unicode_equivalence)

--- a/mimic/__init__.py
+++ b/mimic/__init__.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
 # coding=utf-8
-
 
 from sys import version_info
 
@@ -303,5 +301,3 @@ def main():
 
 fill_homographs()
 
-if __name__ == '__main__':
-    main()

--- a/mimic/__main__.py
+++ b/mimic/__main__.py
@@ -1,0 +1,5 @@
+# coding=utf-8
+from . import main
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-docutils

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ setup(
     name='mimic',
     version="0.0.1",
     packages=find_packages(),
+    install_requires=['docutils'],
     entry_points={
         'console_scripts': [
             'mimic=mimic:main',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup, find_packages
+setup(
+    name='mimic',
+    version="0.0.1",
+    packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'mimic=mimic:main',
+        ],
+    },
+)


### PR DESCRIPTION
*Aside: the effect of this pull request can be tested via:*

    pip install git+git://github.com/rjw57/mimic.git@package-for-pip

A copy of the commit text:

Currently mimic consists solely of one script which is marked as executable.
This is a non-idiomatic way to distribute Python command-line scripts. Add a
simple ``setup.py`` (which will need augmenting with author info, etc) and
re-factor mimic into a single-file module.

The upshot of this is that one can now install mimic directly from pip via

    pip install git+git://github.com/reinderien/mimic.git

and have setuptools create a mimic command which automatically invokes the
correct Python.

For development the usual

    pip install -e .

can be used to use symlink magic to make sure that changes to
``magic/__init__.py`` are respected when launching the mimic wrapper script.

Update README.md with the installation incantation.

A ``__main__.py`` file is also included which allows execution of mimic via

    python -m mimic

One could also add a wrapper script to the repository for this but that's
setuptools' job really.