### PR TITLE
Mention emacs-unicode-troll-stopper in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ Or, if you've been mimicked a little harder,
 
 ### Solutions
 
-[vim-troll-stopper](https://github.com/vim-utils/vim-troll-stopper): vim plugin
+*  [vim-troll-stopper](https://github.com/vim-utils/vim-troll-stopper): vim plugin
 that alerts you by highlighting "troll" Unicode characters in red.
+*  [emacs-unicode-troll-stopper](https://github.com/camsaul/emacs-unicode-troll-stopper) Emacs port of `vim-troll-stopper`.
 
 ### Discussion
 


### PR DESCRIPTION
Hi,
I saw your post on HN today and I realized there was no Emacs equivalent of `vim-troll-stopper` so I wrote one this afternoon. Here's a PR to adds a link to it if that's alright with you.

Best,
Cam