### PR TITLE
Fix Docker builds "properly"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2
+FROM python:3
 COPY . /usr/src/mimic
 RUN pip install /usr/src/mimic
 ENTRYPOINT [ "mimic" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,4 @@
-FROM python:2-onbuild
-ENTRYPOINT [ "python", "/usr/src/app/mimic" ]
+FROM python:2
+COPY . /usr/src/mimic
+RUN pip install /usr/src/mimic
+ENTRYPOINT [ "mimic" ]


### PR DESCRIPTION
The "onbuild" variant of the Python images are, according to the docs, not really intended for production use. Since we actually package mimic properly, we might as well use the non-onbuild image. This removes the need for an (empty) requirements.txt.

In addition, use the Python 3 variant. Let's try to not be part of the hold out Python 2-only brigade :).

Closes #29